### PR TITLE
Fix hook identifiers

### DIFF
--- a/imgui.lua
+++ b/imgui.lua
@@ -21,7 +21,7 @@ end
 local _devMode = false -- cached local variable updated once in a while
 
 function imgui.Hook(name, id, callback)
-	local hookUniqifier = debug.getinfo(1).short_src
+	local hookUniqifier = debug.getinfo(4).short_src
 	hook.Add(name, "IMGUI / " .. id .. " / " .. hookUniqifier, callback)
 end
 


### PR DESCRIPTION
`debug.getinfo(1)` is always the function calling `debug.getinfo` so it would always just point to the library itself, fixed it so it now points to the file where the library is included.