### PR TITLE
Add entity to input collision check

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Start 3D2D context
 imgui.Start3D2D(pos, angles, scale, distanceHide, distanceFadeStart)
 ```
 
-Start 3D2D context on an entity. `pos`/`angles` are automatically transformed from local coordinates into world coordinates.
+Start 3D2D context on an entity. `pos`/`angles` are automatically transformed from local coordinates into world coordinates and the entity will be ignored in obstruction checks.
 
 ```lua
 imgui.Entity3D2D(ent, lpos, lang, scale, distanceHide, distanceFadeStart)

--- a/imgui.lua
+++ b/imgui.lua
@@ -73,7 +73,7 @@ local function isObstructed(eyePos, hitPos, ignoredEntity)
 	end
 end
 
-function imgui.Start3D2D(pos, angles, scale, distanceHide, distanceFadeStart, ignoreEntity)
+function imgui.Start3D2D(pos, angles, scale, distanceHide, distanceFadeStart)
 	if gState.shutdown == true then
 		return
 	end
@@ -144,7 +144,7 @@ function imgui.Start3D2D(pos, angles, scale, distanceHide, distanceFadeStart, ig
 	
 		local hitPos = util.IntersectRayWithPlane(eyepos, eyenormal, pos, planeNormal)
 		if hitPos then
-			local obstructed, obstructer = isObstructed(eyepos, hitPos, ignoreEntity)
+			local obstructed, obstructer = isObstructed(eyepos, hitPos, gState.entity)
 			if obstructed then
 				gState.mx = nil
 				gState.my = nil
@@ -180,7 +180,9 @@ end
 
 function imgui.Entity3D2D(ent, lpos, lang, scale, ...)
 	gState.entity = ent
-	return imgui.Start3D2D(ent:LocalToWorld(lpos), ent:LocalToWorldAngles(lang), scale, ...)
+	local ret = imgui.Start3D2D(ent:LocalToWorld(lpos), ent:LocalToWorldAngles(lang), scale, ...)
+	gState.entity = nil
+	return ret
 end
 
 local function calculateRenderBounds(x, y, w, h)

--- a/imgui.lua
+++ b/imgui.lua
@@ -57,15 +57,14 @@ hook.Add("NotifyShouldTransmit", "IMGUI / ClearRenderBounds", function(ent, shou
 end)
 
 local traceResultTable = {}
-local traceQueryTable = { output = traceResultTable }
-local function isObstructed(eyepos, hitPos)
+local traceQueryTable = { output = traceResultTable, filter = {} }
+local function isObstructed(eyePos, hitPos, ignoredEntity)
 	local q = traceQueryTable
-	q.start = eyepos
+	q.start = eyePos
 	q.endpos = hitPos
-	if not q.filter then
-		q.filter = { LocalPlayer() }
-	end
-
+	q.filter[1] = LocalPlayer()
+	q.filter[2] = ignoredEntity
+	
 	local tr = util.TraceLine(q)
 	if tr.Hit then
 		return true, tr.Entity
@@ -74,7 +73,7 @@ local function isObstructed(eyepos, hitPos)
 	end
 end
 
-function imgui.Start3D2D(pos, angles, scale, distanceHide, distanceFadeStart)
+function imgui.Start3D2D(pos, angles, scale, distanceHide, distanceFadeStart, ignoreEntity)
 	if gState.shutdown == true then
 		return
 	end
@@ -145,7 +144,7 @@ function imgui.Start3D2D(pos, angles, scale, distanceHide, distanceFadeStart)
 	
 		local hitPos = util.IntersectRayWithPlane(eyepos, eyenormal, pos, planeNormal)
 		if hitPos then
-			local obstructed, obstructer = isObstructed(eyepos, hitPos)
+			local obstructed, obstructer = isObstructed(eyepos, hitPos, ignoreEntity)
 			if obstructed then
 				gState.mx = nil
 				gState.my = nil


### PR DESCRIPTION
Add an option to ignore an entity in input obstruction checks

Usage: `imgui.Start3D2D(_, _, _, _, _, entityHere)`