### PR TITLE
Fix cursor position when weapon FOV does not match player FOV

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -28,6 +28,8 @@ std = {
         "tonumber",
         "vector_origin",
         "angle_zero",
+        "ScrW",
+        "ScrH",
     }
 }
 ignore = {"611"}

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Start 3D2D context on an entity. Equivalent to `imgui.Start3D2D`, except a) `pos
 imgui.Entity3D2D(ent, lpos, lang, scale, distanceHide, distanceFadeStart)
 ```
 
+Start 3D2D context on a weapon. Intended for use with weapon viewmodels. Automatically corrects for FOV differences between the player and viewmodel. Unlike `imgui.Entity3D2D`, this does **not** transform local coordinates to world coordinates, as it is assumed you are working with bone positions (which are already in world-space).
+
+```lua
+imgui.Weapon3D2D(swep, pos, ang, scale, distanceHide, distanceFadeStart)
+```
+
 Ends 3D2D Context
 ```lua
 imgui.End3D2D()

--- a/imgui.lua
+++ b/imgui.lua
@@ -35,7 +35,7 @@ local function shouldAcceptInput()
 	end
 
 	-- don't process input if we're doing VGUI stuff (and not in context menu)
-	if vgui.CursorVisible() and vgui.GetHoveredPanel() ~= g_ContextMenu then
+	if vgui.CursorVisible() and vgui.GetHoveredPanel() ~= g_ContextMenu and not vgui.IsHoveringWorld() then
 		return false
 	end
 
@@ -148,7 +148,7 @@ function imgui.Start3D2D(pos, angles, scale, distanceHide, distanceFadeStart)
 		local eyenormal
 
 		if vgui.CursorVisible() and vgui.IsHoveringWorld() then
-			eyenormal = gui.ScreenToVector(gui.MousePos())
+			eyenormal = imgui.ScreenToVector(input.GetCursorPos())
 		else
 			eyenormal = tr.Normal
 		end
@@ -189,6 +189,14 @@ function imgui.Start3D2D(pos, angles, scale, distanceHide, distanceFadeStart)
 	if _devMode then gState._renderStarted = SysTime() end
 
 	return true
+end
+
+function imgui.ScreenToVector(x, y)
+	local view = render.GetViewSetup()
+	local w, h = ScrW(), ScrH()
+	local fov = view.fovviewmodel
+
+	return util.AimVector(view.angles, fov, x, y, w, h)
 end
 
 function imgui.Entity3D2D(ent, lpos, lang, scale, ...)

--- a/imgui.lua
+++ b/imgui.lua
@@ -194,9 +194,21 @@ end
 function imgui.ScreenToVector(x, y)
 	local view = render.GetViewSetup()
 	local w, h = ScrW(), ScrH()
-	local fov = view.fovviewmodel
+	local fov = view.fov
+	if gState.weapon then
+		fov = view.fovviewmodel
+	end
 
 	return util.AimVector(view.angles, fov, x, y, w, h)
+end
+
+function imgui.Weapon3D2D(weapon, pos, ang, scale, ...)
+	gState.weapon = weapon
+	local ret = imgui.Start3D2D(pos, ang, scale, ...)
+	if not ret then
+		gState.weapon = nil
+	end
+	return ret
 end
 
 function imgui.Entity3D2D(ent, lpos, lang, scale, ...)
@@ -370,6 +382,7 @@ function imgui.End3D2D()
 		end
 
 		gState.entity = nil
+		gState.weapon = nil
 	end
 end
 


### PR DESCRIPTION
This is a PR which fixes #35 

As far as I can tell this hasn't broken anything else but if someone can confirm that would be great.

I ended up adding a new function specifically for weapons because we only want to do FOV corrects for view models. 

I did not automatically convert the position and angles using `ENTITY:LocalToWorld(pos)` because I assumed most people will be positioning view model UI relative to bone positions and `ENTITY:GetBonePosition(n)` always returns values in world space coordinates.

Before Fix:

https://github.com/wyozi-gmod/imgui/assets/8341611/be1b8c26-5bd8-4c32-b11b-a447c3dc861c

Notice how the mouse does not line up with the cursor while the screen clicker is active (the virtual cursor is being rendered by the weapon's `SWEP:PostDrawViewMode`)

After Fix:

https://github.com/wyozi-gmod/imgui/assets/8341611/d42aafc4-5370-4436-9cb1-8776b70dddbb

I can interact with both the button positioned in the world **and** the button positioned on the view model accurately to the mouse cursor.