### PR TITLE
Parent Obstructing gui

### DIFF
--- a/imgui.lua
+++ b/imgui.lua
@@ -77,6 +77,8 @@ local function isObstructed(eyePos, hitPos, ignoredEntity, ignoreParent)
 		else
 			q.filter[3] = nil
 		end
+	else
+		q.filter[3] = nil
 	end
 
 	local tr = util.TraceLine(q)

--- a/imgui.lua
+++ b/imgui.lua
@@ -70,9 +70,13 @@ local function isObstructed(eyePos, hitPos, ignoredEntity, ignoreParent)
 	q.endpos = hitPos
 	q.filter[1] = localPlayer
 	q.filter[2] = ignoredEntity
-	local parent = ignoredEntity:GetParent()
-	if IsValid(parent) and ignoreParent == true then
-		q.filter[3] = parent
+	if ignoreParent == true then
+		local parent = ignoredEntity:GetParent()
+		if IsValid(parent) then
+			q.filter[3] = parent
+		else
+			q.filter[3] = nil
+		end
 	end
 
 	local tr = util.TraceLine(q)

--- a/imgui.lua
+++ b/imgui.lua
@@ -64,14 +64,14 @@ end)
 
 local traceResultTable = {}
 local traceQueryTable = { output = traceResultTable, filter = {} }
-local function isObstructed(eyePos, hitPos, ignoredEntity, filterParent)
+local function isObstructed(eyePos, hitPos, ignoredEntity, ignoreParent)
 	local q = traceQueryTable
 	q.start = eyePos
 	q.endpos = hitPos
 	q.filter[1] = localPlayer
 	q.filter[2] = ignoredEntity
 	local parent = ignoredEntity:GetParent()
-	if IsValid(parent) and filterParent == true then
+	if IsValid(parent) and ignoreParent == true then
 		q.filter[3] = parent
 	end
 

--- a/imgui.lua
+++ b/imgui.lua
@@ -64,12 +64,16 @@ end)
 
 local traceResultTable = {}
 local traceQueryTable = { output = traceResultTable, filter = {} }
-local function isObstructed(eyePos, hitPos, ignoredEntity)
+local function isObstructed(eyePos, hitPos, ignoredEntity, filterParent)
 	local q = traceQueryTable
 	q.start = eyePos
 	q.endpos = hitPos
 	q.filter[1] = localPlayer
 	q.filter[2] = ignoredEntity
+	local parent = ignoredEntity:GetParent()
+	if IsValid(parent) and filterParent == true then
+		q.filter[3] = parent
+	end
 
 	local tr = util.TraceLine(q)
 	if tr.Hit then
@@ -157,7 +161,7 @@ function imgui.Start3D2D(pos, angles, scale, distanceHide, distanceFadeStart)
 
 		local hitPos = util.IntersectRayWithPlane(eyepos, eyenormal, pos, planeNormal)
 		if hitPos then
-			local obstructed, obstructer = isObstructed(eyepos, hitPos, gState.entity)
+			local obstructed, obstructer = isObstructed(eyepos, hitPos, gState.entity, true)
 			if obstructed then
 				gState.mx = nil
 				gState.my = nil


### PR DESCRIPTION
if your entity is inside another entity (see pic)
![image](https://github.com/user-attachments/assets/a1616af9-3168-4196-a129-f4cf6b2f2611)

then the cursor gets obstructed.
To fix this we ask if we want to ignore the parent, if so and if parent isvalid then ignore parent :)